### PR TITLE
#8 [FEAT] 질투나요 누르기 구현

### DIFF
--- a/Project/src/main/java/org/sopkaton/Project/common/dto/Success.java
+++ b/Project/src/main/java/org/sopkaton/Project/common/dto/Success.java
@@ -12,13 +12,14 @@ public enum Success {
 	 * 201 CREATED
 	 */
 	CREATE_SUCCESS(HttpStatus.CREATED, "유저 로그인 성공"),
+	DISLIKE_POST_SUCCESS(HttpStatus.OK, "게시물 질투나요 성공"),
 
 
 	/**
 	 * 200 OK
 	 */
 
-	GET_SUCCESS(HttpStatus.CREATED, "조회 성공"),
+	GET_SUCCESS(HttpStatus.OK, "조회 성공"),
 
 	/**
 	 * 204 NO_CONTENT

--- a/Project/src/main/java/org/sopkaton/Project/controller/PostController.java
+++ b/Project/src/main/java/org/sopkaton/Project/controller/PostController.java
@@ -2,12 +2,14 @@ package org.sopkaton.Project.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopkaton.Project.common.ApiResponse;
+import org.sopkaton.Project.common.dto.Success;
+import org.sopkaton.Project.dto.request.DIslikePostRequest;
 import org.sopkaton.Project.service.PostService;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-import static org.sopkaton.Project.common.dto.Success.CREATE_SUCCESS;
-import static org.sopkaton.Project.common.dto.Success.GET_SUCCESS;
+import static org.sopkaton.Project.common.dto.Success.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,5 +26,13 @@ public class PostController {
                                   @RequestPart String postContent,
                                   @RequestPart MultipartFile postImg) throws Exception {
         return ApiResponse.success(CREATE_SUCCESS, postService.createPost(ssaId, postContent, postImg));
+    }
+
+    @PostMapping("/{ssaId}/dislike")
+    public ApiResponse dislikePosts(@PathVariable String ssaId, @RequestBody DIslikePostRequest dIslikePostRequest){
+
+        postService.dislikePosts(ssaId, dIslikePostRequest.postIdList());
+
+        return ApiResponse.success(DISLIKE_POST_SUCCESS);
     }
 }

--- a/Project/src/main/java/org/sopkaton/Project/controller/UserController.java
+++ b/Project/src/main/java/org/sopkaton/Project/controller/UserController.java
@@ -5,10 +5,7 @@ import org.sopkaton.Project.common.ApiResponse;
 import org.sopkaton.Project.dto.response.UserGetResponse;
 import org.sopkaton.Project.service.UserService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.sopkaton.Project.common.dto.Success;
 
 @RestController
@@ -18,7 +15,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/login/{ssaId}")
+    @PostMapping("/login/{ssaId}")
     public ApiResponse<UserGetResponse> login(@PathVariable String ssaId) {
         return ApiResponse.success(Success.CREATE_SUCCESS,userService.login(ssaId));
     }

--- a/Project/src/main/java/org/sopkaton/Project/domain/UserPostInteractions.java
+++ b/Project/src/main/java/org/sopkaton/Project/domain/UserPostInteractions.java
@@ -1,0 +1,29 @@
+package org.sopkaton.Project.domain;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserPostInteractions {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long upiId;
+
+    String ssaId;
+    Long postId;
+
+    @Builder
+    UserPostInteractions(String ssaId, Long postId){
+        this.ssaId = ssaId;
+        this.postId=postId;
+    }
+}

--- a/Project/src/main/java/org/sopkaton/Project/dto/request/DIslikePostRequest.java
+++ b/Project/src/main/java/org/sopkaton/Project/dto/request/DIslikePostRequest.java
@@ -1,0 +1,9 @@
+package org.sopkaton.Project.dto.request;
+
+import java.util.List;
+
+public record DIslikePostRequest (
+    List<Long> postIdList
+){
+
+}

--- a/Project/src/main/java/org/sopkaton/Project/repository/PostRepository.java
+++ b/Project/src/main/java/org/sopkaton/Project/repository/PostRepository.java
@@ -3,9 +3,18 @@ package org.sopkaton.Project.repository;
 import org.sopkaton.Project.domain.Post;
 import org.sopkaton.Project.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByUser(User user);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.postDislikeCount = p.postDislikeCount +1 WHERE p.postId = :postId")
+    void updateDislikeCount(@Param("postId") Long postId);
+
+
 }

--- a/Project/src/main/java/org/sopkaton/Project/repository/UserPostInteractionsRepository.java
+++ b/Project/src/main/java/org/sopkaton/Project/repository/UserPostInteractionsRepository.java
@@ -1,0 +1,7 @@
+package org.sopkaton.Project.repository;
+
+import org.sopkaton.Project.domain.UserPostInteractions;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserPostInteractionsRepository extends JpaRepository<UserPostInteractions, Long> {
+}

--- a/Project/src/main/java/org/sopkaton/Project/repository/UserRepository.java
+++ b/Project/src/main/java/org/sopkaton/Project/repository/UserRepository.java
@@ -2,6 +2,13 @@ package org.sopkaton.Project.repository;
 
 import org.sopkaton.Project.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, String> {
+
+    @Modifying
+    @Query("UPDATE User u SET u.dislikeCount =u.dislikeCount+1 WHERE u.ssaId=:ssaId")
+    void updateDislikeCount(@Param("ssaId") String ssaId);
 }

--- a/Project/src/main/java/org/sopkaton/Project/service/PostService.java
+++ b/Project/src/main/java/org/sopkaton/Project/service/PostService.java
@@ -1,11 +1,16 @@
 package org.sopkaton.Project.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.sopkaton.Project.domain.Post;
+import org.sopkaton.Project.domain.User;
+import org.sopkaton.Project.domain.UserPostInteractions;
 import org.sopkaton.Project.external.S3Service;
 import org.sopkaton.Project.repository.PostRepository;
+import org.sopkaton.Project.repository.UserPostInteractionsRepository;
 import org.sopkaton.Project.repository.UserRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -19,6 +24,7 @@ public class PostService {
     private final S3Service s3Service;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final UserPostInteractionsRepository userPostInteractionsRepository;
 
     public Post createPost(String ssaId, String postContent, MultipartFile postImg) throws Exception {
         String imgUrl = s3Service.uploadImage("post/", postImg);
@@ -39,5 +45,15 @@ public class PostService {
 
     public List<Post> getPostsByUser(String ssaId) {
         return postRepository.findByUser(userRepository.findById(ssaId).get());
+    }
+
+    @Transactional
+    public void dislikePosts(String ssaId, List<Long> postIdList){
+        for(Long postId : postIdList){
+            postRepository.updateDislikeCount(postId);
+            Post post = postRepository.findById(postId).orElseThrow(()-> new EntityNotFoundException("없는 게시물입니다."));
+            userRepository.updateDislikeCount(post.getUser().getSsaId());
+            UserPostInteractions postInteractions = userPostInteractionsRepository.save(UserPostInteractions.builder().postId(postId).ssaId(ssaId).build());
+        }
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #8 

## 📋 구현 기능 명세
- [x] 질투나요 누른 게시물 질투나요 수 1개증가
- [x] 질투나요 누른 게시물 유저 질투나요 수 1개 증가
- [x] 유저가 질투나요 누른 게시물 저장

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```json
{
    "code": 200,
    "message": "게시물 질투나요 성공",
    "data": null
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /{ssaId}/dislike
